### PR TITLE
Claude version of 4LS for HLG

### DIFF
--- a/tests/unit/test_polymer_hamiltonians.py
+++ b/tests/unit/test_polymer_hamiltonians.py
@@ -1,0 +1,539 @@
+"""
+Unit tests for the Polymer class in ufss/HLG/Hamiltonians.py
+
+Organisation
+------------
+Test3LS  - regression tests for existing 2-site 3LS behaviour.
+           These MUST continue to pass after the 4LS extension is added.
+Test3LSCouplingK1  - tests for the new K1 (b†b) coupling added to 3LS.
+                     These will FAIL until K1 is implemented.
+Test4LS  - specification / correctness tests for the new 4LS support.
+           These will FAIL until 4LS is implemented.
+
+Operator naming (user's convention)
+-------------------------------------
+For a single 3LS site (states g, e, f):
+  a†  = |e><g|  (+1 excitation, 0→1)
+  b†  = |f><g|  (+2 excitation, 0→2)
+  c†  = |f><e|  (+1 excitation, 1→2)
+
+  J   coupling  a†_i a_j + h.c.  (singly excited manifold)
+  K   coupling  c†_i a_j + h.c.  (doubly excited manifold)
+  K1  coupling  b†_i b_j + h.c.  (doubly excited manifold) ← NEW, missing from 3LS
+  L   coupling  c†_i c_j + h.c.  (triply excited manifold)
+
+For a single 4LS site (states g, e, f, h):
+  d†  = |h><g|  (+3 excitation, 0→3)
+  p†  = |h><e|  (+2 excitation, 1→3)
+  q†  = |h><f|  (+1 excitation, 2→3)
+
+  L1  coupling  q†_i a_j + h.c.  (triply excited)
+  L2  coupling  p†_i b_j + h.c.  (triply excited)
+  L3  coupling  d†_i d_j + h.c.  (triply excited)
+  M0  coupling  q†_i c_j + h.c.  (quadruply excited)
+  M1  coupling  p†_i p_j + h.c.  (quadruply excited)
+  N0  coupling  q†_i q_j + h.c.  (quintuply excited)
+
+Dipole ordering for 4LS (6-vector form per site):
+  index 0: g<->e (d_ge)
+  index 1: e<->f (d_ef)
+  index 2: f<->h (d_fh)
+  index 3: g<->f (d_gf)
+  index 4: g<->h (d_gh)
+  index 5: e<->h (d_eh)
+
+Dipole shortcut (3-vector form per site = ladder-only):
+  index 0: g<->e
+  index 1: e<->f
+  index 2: f<->h
+  (d_gf, d_gh, d_eh are all zero)
+"""
+
+import numpy as np
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from ufss.HLG.Hamiltonians import Polymer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _3LS_single(e1=1.0, e2=2.5, d01=None, d12=None, d02=None):
+    """Build a single-site 3LS Polymer."""
+    d01 = d01 if d01 is not None else [1, 0, 0]
+    d12 = d12 if d12 is not None else [1, 0, 0]
+    d02 = d02 if d02 is not None else [0, 0, 0]
+    site_energies = [[e1, e2]]
+    site_couplings = [[], [], []]
+    dipoles = np.array([[d01, d12, d02]])   # shape (1, 3, 3)
+    return Polymer(site_energies, site_couplings, dipoles)
+
+
+def _3LS_dimer(e1=1.0, e2=2.5, J=0.0, K=0.0, L=0.0):
+    """Build a degenerate 2-site 3LS dimer using the matrix coupling format."""
+    site_energies = [[e1, e2], [e1, e2]]
+    J_mat = [[0, J], [J, 0]]
+    K_mat = [[0, K], [K, 0]]
+    L_mat = [[0, L], [L, 0]]
+    site_couplings = [J_mat, K_mat, L_mat]
+    dipoles = np.array([
+        [[1, 0, 0], [1, 0, 0], [0, 0, 0]],
+        [[1, 0, 0], [1, 0, 0], [0, 0, 0]],
+    ])
+    return Polymer(site_energies, site_couplings, dipoles)
+
+
+def _4LS_single(e1=1.0, e2=2.5, e3=5.0, dipoles=None):
+    """Build a single-site 4LS Polymer (ladder dipoles by default)."""
+    site_energies = [[e1, e2, e3]]
+    site_couplings = {}
+    if dipoles is None:
+        # 3-vector shortcut = ladder-only
+        dipoles = np.array([[[1, 0, 0], [1, 0, 0], [1, 0, 0]]])  # shape (1, 3, 3)
+    return Polymer(site_energies, site_couplings, dipoles)
+
+
+def _4LS_dimer(e1=1.0, e2=2.5, e3=5.0, couplings=None):
+    """Build a degenerate 2-site 4LS dimer."""
+    site_energies = [[e1, e2, e3], [e1, e2, e3]]
+    site_couplings = couplings if couplings is not None else {}
+    dipoles = np.array([
+        [[1, 0, 0], [1, 0, 0], [1, 0, 0]],
+        [[1, 0, 0], [1, 0, 0], [1, 0, 0]],
+    ])
+    return Polymer(site_energies, site_couplings, dipoles)
+
+
+# ---------------------------------------------------------------------------
+# 3LS regression tests
+# ---------------------------------------------------------------------------
+
+class Test3LS:
+    """Regression tests – must pass before and after 4LS is added."""
+
+    def test_detection(self):
+        p = _3LS_single()
+        assert p.N == 3
+
+    def test_single_site_hilbert_dim(self):
+        p = _3LS_single()
+        assert p.H_dim == 3
+
+    def test_dimer_hilbert_dim(self):
+        p = _3LS_dimer()
+        assert p.H_dim == 9
+
+    def test_single_site_hamiltonian(self):
+        """H is diagonal in site basis with energies [0, e1, e2]."""
+        e1, e2 = 1.0, 2.5
+        p = _3LS_single(e1=e1, e2=e2)
+        np.testing.assert_allclose(
+            p.electronic_hamiltonian, np.diag([0.0, e1, e2]), atol=1e-12
+        )
+
+    def test_hamiltonian_hermitian(self):
+        p = _3LS_dimer(J=0.1, K=0.2, L=0.3)
+        H = p.electronic_hamiltonian
+        np.testing.assert_allclose(H, H.conj().T, atol=1e-12)
+
+    def test_J_coupling_eigenvalues(self):
+        """J coupling splits the singly-excited doublet by 2J."""
+        e1, J = 1.0, 0.15
+        p = _3LS_dimer(e1=e1, J=J)
+        e, _ = p.make_manifold_eigensystem(1)
+        np.testing.assert_allclose(np.sort(e), [e1 - J, e1 + J], atol=1e-12)
+
+    def test_K_coupling_doubly_excited_structure(self):
+        """K coupling produces correct off-diagonal structure in doubly-excited H.
+
+        For a degenerate dimer with only K coupling the doubly-excited 3x3
+        Hamiltonian (states |g,f>, |e,e>, |f,g> in Kron order) is:
+            [[e2,   K,   0 ],
+             [K,  2*e1,  K ],
+             [0,    K,  e2 ]]
+        """
+        e1, e2, K = 1.0, 2.5, 0.2
+        p = _3LS_dimer(e1=e1, e2=e2, K=K)
+        H2 = p.extract_manifold(p.electronic_hamiltonian, 2)
+        expected = np.array([
+            [e2,    K,   0.0],
+            [K,  2*e1,   K  ],
+            [0.0,   K,   e2 ],
+        ])
+        np.testing.assert_allclose(H2, expected, atol=1e-12)
+
+    def test_L_coupling_triply_excited_structure(self):
+        """L (c†c) coupling splits the |e,f>/<|f,e> doublet in manifold 3.
+
+        For a degenerate dimer the triply-excited 2x2 block is:
+            [[e1+e2,  L ],
+             [L,   e1+e2]]
+        with eigenvalues (e1+e2) ± L.
+        """
+        e1, e2, L = 1.0, 2.5, 0.3
+        p = _3LS_dimer(e1=e1, e2=e2, L=L)
+        H3 = p.extract_manifold(p.electronic_hamiltonian, 3)
+        assert H3.shape == (2, 2), f"Expected 2x2, got {H3.shape}"
+        expected = np.array([[e1 + e2, L], [L, e1 + e2]])
+        np.testing.assert_allclose(H3, expected, atol=1e-12)
+
+    def test_L_coupling_eigenvalues(self):
+        e1, e2, L = 1.0, 2.5, 0.3
+        p = _3LS_dimer(e1=e1, e2=e2, L=L)
+        e, _ = p.make_manifold_eigensystem(3)
+        np.testing.assert_allclose(
+            np.sort(e), [e1 + e2 - L, e1 + e2 + L], atol=1e-12
+        )
+
+    def test_no_K1_coupling_in_doubly_excited(self):
+        """Documents that b†b (K1) is NOT in the existing 3LS code.
+
+        With e2 != 2*e1, |g,f> and |f,g> are degenerate at e2 but
+        |e,e> is at 2*e1.  Without K1 the |g,f>/<|f,g> pair must be
+        uncoupled (off-diagonal element H2[0,2] = 0).
+        """
+        e1, e2 = 1.0, 2.5          # 2*e1 = 2.0 ≠ e2 = 2.5
+        p = _3LS_dimer(e1=e1, e2=e2)   # no couplings
+        H2 = p.extract_manifold(p.electronic_hamiltonian, 2)
+        # States: |g,f>(0), |e,e>(1), |f,g>(2)
+        # K1 would appear in H2[0,2] and H2[2,0]
+        np.testing.assert_allclose(H2[0, 2], 0.0, atol=1e-12,
+            err_msg="K1 coupling unexpectedly present in existing 3LS code")
+        np.testing.assert_allclose(H2[2, 0], 0.0, atol=1e-12)
+
+    def test_dipole_hermitian(self):
+        p = _3LS_dimer(J=0.1, K=0.1, L=0.1)
+        for pol in ['x', 'y', 'z']:
+            mu = p.mu_dict[pol]
+            np.testing.assert_allclose(mu, mu.conj().T, atol=1e-12,
+                err_msg=f"mu_{pol} is not Hermitian")
+
+    def test_dipole_up_connects_correct_manifolds(self):
+        """mu_up (raising) has non-zero elements only for n→n+1 transitions."""
+        e1, e2 = 1.0, 2.5
+        p = _3LS_single(e1=e1, e2=e2,
+                        d01=[1, 0, 0], d12=[0, 1, 0], d02=[0, 0, 0])
+        mu_up_x = p.mu_up_dict['x']
+        mu_up_y = p.mu_up_dict['y']
+
+        m01_x = p.extract_coherence(mu_up_x, 1, 0)   # |e> <- |g|, x-pol
+        m12_y = p.extract_coherence(mu_up_y, 2, 1)   # |f> <- |e|, y-pol
+        m02_x = p.extract_coherence(mu_up_x, 2, 0)   # direct, should be 0
+
+        np.testing.assert_allclose(m01_x, [[1.0]], atol=1e-12)
+        np.testing.assert_allclose(m12_y, [[1.0]], atol=1e-12)
+        np.testing.assert_allclose(m02_x, [[0.0]], atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# 3LS K1 (b†b) coupling tests – FAIL until K1 is implemented
+# ---------------------------------------------------------------------------
+
+class Test3LSCouplingK1:
+    """Tests for the new K1 (b†b) coupling to be added to 3LS.
+
+    These tests will fail until the K1 coupling is implemented.
+    After implementation they serve as regression tests alongside Test3LS.
+    """
+
+    def _dimer_with_K1(self, K1, e1=1.0, e2=2.5):
+        """3LS dimer using new dict coupling format with only K1 nonzero."""
+        site_energies = [[e1, e2], [e1, e2]]
+        site_couplings = {
+            'J':  [[0, 0.0], [0.0, 0]],
+            'K':  [[0, 0.0], [0.0, 0]],
+            'K1': [[0, K1 ], [K1,  0]],
+            'L':  [[0, 0.0], [0.0, 0]],
+        }
+        dipoles = np.array([
+            [[1, 0, 0], [1, 0, 0], [0, 0, 0]],
+            [[1, 0, 0], [1, 0, 0], [0, 0, 0]],
+        ])
+        return Polymer(site_energies, site_couplings, dipoles)
+
+    def test_dict_coupling_accepted_for_3LS(self):
+        """Polymer accepts dict coupling input for 3LS."""
+        p = self._dimer_with_K1(K1=0.1)
+        assert p.N == 3
+
+    def test_K1_doubly_excited_structure(self):
+        """K1 coupling adds H2[0,2] = H2[2,0] = K1 (|g,f> <-> |f,g>).
+
+        With only K1, the doubly-excited 3x3 block is:
+            [[e2,   0,   K1],
+             [0,  2*e1,  0 ],
+             [K1,  0,   e2 ]]
+        """
+        e1, e2, K1 = 1.0, 2.5, 0.15
+        p = self._dimer_with_K1(K1=K1, e1=e1, e2=e2)
+        H2 = p.extract_manifold(p.electronic_hamiltonian, 2)
+        expected = np.array([
+            [e2,    0.0,  K1 ],
+            [0.0, 2*e1,   0.0],
+            [K1,   0.0,   e2 ],
+        ])
+        np.testing.assert_allclose(H2, expected, atol=1e-12)
+
+    def test_K1_eigenvalues(self):
+        """K1 splits |g,f>/<|f,g> by 2*K1; |e,e> is unaffected."""
+        e1, e2, K1 = 1.0, 2.5, 0.15
+        p = self._dimer_with_K1(K1=K1, e1=e1, e2=e2)
+        e, _ = p.make_manifold_eigensystem(2)
+        expected = np.sort([2 * e1, e2 - K1, e2 + K1])
+        np.testing.assert_allclose(np.sort(e), expected, atol=1e-12)
+
+    def test_old_list_format_unchanged(self):
+        """Old [J, K, L] list format still works; K1 defaults to zero."""
+        p = _3LS_dimer(e1=1.0, e2=2.5, J=0.1, K=0.2, L=0.3)
+        H2 = p.extract_manifold(p.electronic_hamiltonian, 2)
+        # K1 term is H2[0,2]; must still be zero
+        np.testing.assert_allclose(H2[0, 2], 0.0, atol=1e-12)
+        np.testing.assert_allclose(H2[2, 0], 0.0, atol=1e-12)
+
+    def test_extended_list_format(self):
+        """[J, K, L, K1] 4-element list format sets K1."""
+        e1, e2, K1 = 1.0, 2.5, 0.15
+        site_energies = [[e1, e2], [e1, e2]]
+        site_couplings = [
+            [[0, 0.0], [0.0, 0]],   # J
+            [[0, 0.0], [0.0, 0]],   # K
+            [[0, 0.0], [0.0, 0]],   # L
+            [[0, K1 ], [K1,  0]],   # K1
+        ]
+        dipoles = np.array([
+            [[1, 0, 0], [1, 0, 0], [0, 0, 0]],
+            [[1, 0, 0], [1, 0, 0], [0, 0, 0]],
+        ])
+        p = Polymer(site_energies, site_couplings, dipoles)
+        H2 = p.extract_manifold(p.electronic_hamiltonian, 2)
+        np.testing.assert_allclose(H2[0, 2], K1, atol=1e-12)
+        np.testing.assert_allclose(H2[2, 0], K1, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# 4LS tests – FAIL until 4LS is implemented
+# ---------------------------------------------------------------------------
+
+class Test4LS:
+    """Specification tests for the new FourLevelPolymer / 4LS support.
+
+    These tests will fail until 4LS is implemented and then serve as
+    regression tests.
+    """
+
+    # --- detection and basic structure ---
+
+    def test_detection(self):
+        """N=4 when site_energies elements have length 3."""
+        p = _4LS_single()
+        assert p.N == 4
+
+    def test_single_site_hilbert_dim(self):
+        p = _4LS_single()
+        assert p.H_dim == 4
+
+    def test_dimer_hilbert_dim(self):
+        """2-site 4LS: 4^2 = 16 states, all have total occupation ≤ 6."""
+        p = _4LS_dimer()
+        assert p.H_dim == 16
+
+    def test_maximum_manifold_auto(self):
+        """Auto maximum_manifold for 4LS is 3 * num_sites."""
+        p = _4LS_dimer()          # 2 sites
+        assert p.maximum_manifold == 6
+
+    # --- single-site Hamiltonian ---
+
+    def test_single_site_hamiltonian(self):
+        """H is diagonal with energies [0, e1, e2, e3]."""
+        e1, e2, e3 = 1.0, 2.5, 5.0
+        p = _4LS_single(e1=e1, e2=e2, e3=e3)
+        expected = np.diag([0.0, e1, e2, e3])
+        np.testing.assert_allclose(p.electronic_hamiltonian, expected, atol=1e-12)
+
+    # --- Hamiltonian is Hermitian ---
+
+    def test_hamiltonian_hermitian_all_couplings(self):
+        """H is Hermitian when all coupling types are nonzero."""
+        couplings = {
+            'J':  [[0, 0.10], [0.10, 0]],
+            'K':  [[0, 0.09], [0.09, 0]],
+            'K1': [[0, 0.08], [0.08, 0]],
+            'L':  [[0, 0.07], [0.07, 0]],
+            'L1': [[0, 0.06], [0.06, 0]],
+            'L2': [[0, 0.05], [0.05, 0]],
+            'L3': [[0, 0.04], [0.04, 0]],
+            'M0': [[0, 0.03], [0.03, 0]],
+            'M1': [[0, 0.02], [0.02, 0]],
+            'N0': [[0, 0.01], [0.01, 0]],
+        }
+        p = _4LS_dimer(couplings=couplings)
+        H = p.electronic_hamiltonian
+        np.testing.assert_allclose(H, H.conj().T, atol=1e-12)
+
+    # --- J coupling (singly excited, same physics as 3LS) ---
+
+    def test_J_coupling_eigenvalues(self):
+        """J coupling splits the singly-excited doublet by 2J."""
+        e1, J = 1.0, 0.15
+        p = _4LS_dimer(couplings={'J': [[0, J], [J, 0]]})
+        e, _ = p.make_manifold_eigensystem(1)
+        np.testing.assert_allclose(np.sort(e), [e1 - J, e1 + J], atol=1e-12)
+
+    # --- K1 coupling (doubly excited, new to 4LS via 3LS extension) ---
+
+    def test_K1_default_zero(self):
+        """No K1 entry in couplings → H2[|g,f>, |f,g>] = 0."""
+        e1, e2 = 1.0, 2.5
+        p = _4LS_dimer()
+        H2 = p.extract_manifold(p.electronic_hamiltonian, 2)
+        # doubly-excited manifold must be diagonal for zero couplings
+        np.testing.assert_allclose(H2, np.diag(np.diag(H2)), atol=1e-12)
+
+    def test_K1_coupling_eigenvalues(self):
+        """K1 (b†b) splits |g,f>/<|f,g> by 2*K1; |e,e> unchanged."""
+        e1, e2, K1 = 1.0, 2.5, 0.15
+        p = _4LS_dimer(e1=e1, e2=e2, couplings={'K1': [[0, K1], [K1, 0]]})
+        e, _ = p.make_manifold_eigensystem(2)
+        expected = np.sort([2 * e1, e2 - K1, e2 + K1])
+        np.testing.assert_allclose(np.sort(e), expected, atol=1e-12)
+
+    # --- L coupling (triply excited, same as 3LS c†c) ---
+
+    def test_L_coupling_triply_excited(self):
+        """L (c†c) splits |e,f>/<|f,e> by 2L; |g,h>/<|h,g> unchanged."""
+        e1, e2, e3, L = 1.0, 2.5, 5.0, 0.2
+        # e1+e2 = 3.5 ≠ e3 = 5.0, so the two pairs are well separated
+        p = _4LS_dimer(e1=e1, e2=e2, e3=e3, couplings={'L': [[0, L], [L, 0]]})
+        e, _ = p.make_manifold_eigensystem(3)
+        expected = np.sort([e1+e2-L, e1+e2+L, e3, e3])
+        np.testing.assert_allclose(np.sort(e), expected, atol=1e-12)
+
+    # --- L3 coupling (d†d, triply excited, new for 4LS) ---
+
+    def test_L3_coupling_triply_excited(self):
+        """L3 (d†d) splits |g,h>/<|h,g> by 2*L3; |e,f>/<|f,e> unchanged."""
+        e1, e2, e3, L3 = 1.0, 2.5, 5.0, 0.2
+        p = _4LS_dimer(e1=e1, e2=e2, e3=e3, couplings={'L3': [[0, L3], [L3, 0]]})
+        e, _ = p.make_manifold_eigensystem(3)
+        expected = np.sort([e1+e2, e1+e2, e3-L3, e3+L3])
+        np.testing.assert_allclose(np.sort(e), expected, atol=1e-12)
+
+    # --- M1 coupling (p†p, quadruply excited) ---
+
+    def test_M1_coupling_quadruply_excited(self):
+        """M1 (p†p) splits |e,h>/<|h,e> by 2*M1.
+
+        |e,h> and |h,e> both have energy e1+e3.
+        With e1=1, e2=2.5, e3=5: e1+e3=6, e2+e2=5, e1+e3 ≠ 2*e2.
+        M1 only couples the |e,h>/<|h,e> pair.
+        """
+        e1, e2, e3, M1 = 1.0, 2.5, 5.0, 0.12
+        p = _4LS_dimer(e1=e1, e2=e2, e3=e3, couplings={'M1': [[0, M1], [M1, 0]]})
+        e, _ = p.make_manifold_eigensystem(4)
+        e = np.sort(e)
+        # Find the pair that splits: eigenvalues near e1+e3 should be
+        # (e1+e3)-M1 and (e1+e3)+M1; the pair near 2*e2 should be unsplit
+        idx_low  = np.argmin(np.abs(e - (e1 + e3 - M1)))
+        idx_high = np.argmin(np.abs(e - (e1 + e3 + M1)))
+        np.testing.assert_allclose(e[idx_low],  e1 + e3 - M1, atol=1e-12)
+        np.testing.assert_allclose(e[idx_high], e1 + e3 + M1, atol=1e-12)
+
+    # --- N0 coupling (q†q, quintuply excited) ---
+
+    def test_N0_coupling_quintuply_excited(self):
+        """N0 (q†q) splits |f,h>/<|h,f> by 2*N0."""
+        e1, e2, e3, N0 = 1.0, 2.5, 5.0, 0.08
+        p = _4LS_dimer(e1=e1, e2=e2, e3=e3, couplings={'N0': [[0, N0], [N0, 0]]})
+        e, _ = p.make_manifold_eigensystem(5)
+        # Only states in manifold 5 are |f,h> (e2+e3=7.5) and |h,f> (e3+e2=7.5)
+        expected = np.sort([e2 + e3 - N0, e2 + e3 + N0])
+        np.testing.assert_allclose(np.sort(e), expected, atol=1e-12)
+
+    # --- eigensystem completeness ---
+
+    def test_eigensystem_covers_all_manifolds(self):
+        """electronic_eigenvectors covers all manifolds up to maximum_manifold."""
+        p = _4LS_single()
+        # For single site, maximum_manifold = 3; eigenvectors should be 4x4 identity
+        V = p.electronic_eigenvectors
+        assert V.shape == (4, 4)
+        np.testing.assert_allclose(V @ V.T, np.eye(4), atol=1e-12)
+
+    # --- dipole operators ---
+
+    def test_dipole_hermitian(self):
+        p = _4LS_single()
+        for pol in ['x', 'y', 'z']:
+            mu = p.mu_dict[pol]
+            np.testing.assert_allclose(mu, mu.conj().T, atol=1e-12,
+                err_msg=f"mu_{pol} not Hermitian")
+
+    def test_dipole_ladder_shortcut(self):
+        """3-vector (ladder-only) input → direct transitions d_gf, d_gh, d_eh are zero."""
+        p = _4LS_single()
+        mu_up = p.mu_up_dict['x']
+
+        # Ladder transitions should be nonzero (all d=1 x-polarised)
+        m01 = p.extract_coherence(mu_up, 1, 0)   # e <- g
+        m12 = p.extract_coherence(mu_up, 2, 1)   # f <- e
+        m23 = p.extract_coherence(mu_up, 3, 2)   # h <- f
+        np.testing.assert_allclose(np.abs(m01[0, 0]), 1.0, atol=1e-12)
+        np.testing.assert_allclose(np.abs(m12[0, 0]), 1.0, atol=1e-12)
+        np.testing.assert_allclose(np.abs(m23[0, 0]), 1.0, atol=1e-12)
+
+        # Direct transitions should be zero
+        m02 = p.extract_coherence(mu_up, 2, 0)   # f <- g  (d_gf)
+        m03 = p.extract_coherence(mu_up, 3, 0)   # h <- g  (d_gh)
+        m13 = p.extract_coherence(mu_up, 3, 1)   # h <- e  (d_eh)
+        np.testing.assert_allclose(m02, [[0.0]], atol=1e-12)
+        np.testing.assert_allclose(m03, [[0.0]], atol=1e-12)
+        np.testing.assert_allclose(m13, [[0.0]], atol=1e-12)
+
+    def test_dipole_full_six_transitions(self):
+        """All 6 per-site dipole transitions can be set independently.
+
+        Dipole array shape (1, 6, 3):
+          [0] g<->e  x-only
+          [1] e<->f  y-only
+          [2] f<->h  z-only
+          [3] g<->f  x, magnitude 0.5
+          [4] g<->h  x, magnitude 0.3
+          [5] e<->h  x, magnitude 0.2
+        """
+        dipoles = np.array([[
+            [1.0, 0,   0],   # d_ge
+            [0,   1.0, 0],   # d_ef
+            [0,   0,   1.0], # d_fh
+            [0.5, 0,   0],   # d_gf
+            [0.3, 0,   0],   # d_gh
+            [0.2, 0,   0],   # d_eh
+        ]])
+        p = Polymer([[1.0, 2.5, 5.0]], {}, dipoles)
+
+        mux = p.mu_up_dict['x']
+        muy = p.mu_up_dict['y']
+        muz = p.mu_up_dict['z']
+
+        np.testing.assert_allclose(np.abs(p.extract_coherence(mux, 1, 0)[0,0]), 1.0, atol=1e-12)
+        np.testing.assert_allclose(np.abs(p.extract_coherence(muy, 2, 1)[0,0]), 1.0, atol=1e-12)
+        np.testing.assert_allclose(np.abs(p.extract_coherence(muz, 3, 2)[0,0]), 1.0, atol=1e-12)
+        np.testing.assert_allclose(np.abs(p.extract_coherence(mux, 2, 0)[0,0]), 0.5, atol=1e-12)
+        np.testing.assert_allclose(np.abs(p.extract_coherence(mux, 3, 0)[0,0]), 0.3, atol=1e-12)
+        np.testing.assert_allclose(np.abs(p.extract_coherence(mux, 3, 1)[0,0]), 0.2, atol=1e-12)
+
+    # --- make_4LS convenience function ---
+
+    def test_make_4LS_runs(self):
+        """make_4LS() creates the output files without error (requires tmp dir)."""
+        import tempfile
+        from ufss.HLG.make_simple_systems import make_4LS
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_4LS(tmpdir, omega0=1.0, tau_deph=100.0, kT=0.1)
+            assert os.path.exists(os.path.join(tmpdir, 'closed', 'H.npz'))
+            assert os.path.exists(os.path.join(tmpdir, 'closed', 'mu.npz'))

--- a/ufss/HLG/Hamiltonians.py
+++ b/ufss/HLG/Hamiltonians.py
@@ -488,7 +488,10 @@ class Polymer:
         self.num_sites = len(site_energies)
 
         if isinstance(site_energies[0], list):
-            self.N = 3
+            if len(site_energies[0]) == 2:
+                self.N = 3
+            else:
+                self.N = 4
         else:
             self.N = 2
             self.energies = site_energies
@@ -509,24 +512,51 @@ class Polymer:
                 self.energies.append(egy)
                 egy = site_energies[i][1]  # list of second excitation energies
                 self.double_energies.append(egy)
-            # Couplings matrices for 3LS
+            # Couplings matrices for 3LS — supports dict, 4-element list (J,K,L,K1), and old 3-element list
             if self.num_sites == 1:
                 self.J_list = []
                 self.K_list = []
+                self.K1_list = []
                 self.L_list = []
+            elif isinstance(site_couplings, dict):
+                self.J_list, self.K_list, self.K1_list, self.L_list = \
+                    self._parse_coupling_dict(['J', 'K', 'K1', 'L'], site_couplings)
             elif isinstance(site_couplings[0][0], list) or isinstance(site_couplings[0][0], np.ndarray):
                 self.J_list = []
                 self.K_list = []
+                self.K1_list = []
                 self.L_list = []
+                k1_mat = site_couplings[3] if len(site_couplings) > 3 else None
                 for i in range(self.num_sites):
                     for j in range(i+1,self.num_sites):
                         self.J_list.append(site_couplings[0][i][j])
                         self.K_list.append(site_couplings[1][i][j])
                         self.L_list.append(site_couplings[2][i][j])
+                        self.K1_list.append(k1_mat[i][j] if k1_mat is not None else 0.0)
             else:
                 self.J_list = site_couplings[0]
                 self.K_list = site_couplings[1]
                 self.L_list = site_couplings[2]
+                self.K1_list = [0.0] * len(self.J_list)
+
+        if self.N == 4:
+            self.energies = []
+            self.double_energies = []
+            self.triple_energies = []
+            for i in range(self.num_sites):
+                self.energies.append(site_energies[i][0])
+                self.double_energies.append(site_energies[i][1])
+                self.triple_energies.append(site_energies[i][2])
+            _4ls_keys = ['J', 'K', 'K1', 'L', 'L1', 'L2', 'L3', 'M0', 'M1', 'N0']
+            if isinstance(site_couplings, dict):
+                (self.J_list, self.K_list, self.K1_list, self.L_list,
+                 self.L1_list, self.L2_list, self.L3_list,
+                 self.M0_list, self.M1_list, self.N0_list) = \
+                    self._parse_coupling_dict(_4ls_keys, site_couplings)
+            else:
+                n_pairs = self.num_sites * (self.num_sites - 1) // 2
+                for key in _4ls_keys:
+                    setattr(self, key + '_list', [0.0] * n_pairs)
 
         self.dipoles = dipoles
         self.pols = ['x', 'y', 'z']
@@ -564,6 +594,25 @@ class Polymer:
 
             self.empty = self.basis(0, 0)
 
+        # For a 4LS
+        if self.N == 4:
+            self.up10 = self.basis(1, 0)  # a† = |e><g|
+            self.up20 = self.basis(2, 0)  # b† = |f><g|
+            self.up21 = self.basis(2, 1)  # c† = |f><e|
+            self.up30 = self.basis(3, 0)  # d† = |h><g|
+            self.up31 = self.basis(3, 1)  # p† = |h><e|
+            self.up32 = self.basis(3, 2)  # q† = |h><f|
+            self.down01 = self.basis(0, 1)  # a
+            self.down02 = self.basis(0, 2)  # b
+            self.down12 = self.basis(1, 2)  # c
+            self.down03 = self.basis(0, 3)  # d
+            self.down13 = self.basis(1, 3)  # p
+            self.down23 = self.basis(2, 3)  # q
+            self.occupied_1 = self.basis(1, 1)
+            self.occupied_2 = self.basis(2, 2)
+            self.occupied_3 = self.basis(3, 3)
+            self.empty = self.basis(0, 0)
+
         ### Kron up the single 2LS operators to act on the full Hilbert space of the polymer
 
         self.set_up_list()
@@ -584,6 +633,35 @@ class Polymer:
             self.set_down01_list()
             self.set_down12_list()
             self.set_down02_list()
+            if self.num_sites > 1:
+                self.set_exchange_list_K1()
+
+        # For 4LS
+        if self.N == 4:
+            self.set_doubly_occupied_list()
+            self.set_exchange_list_G()
+            self.set_exchange_list_GG()
+            self.set_exchange_list_C()
+            self.set_up10_list()
+            self.set_up21_list()
+            self.set_up20_list()
+            self.set_down01_list()
+            self.set_down12_list()
+            self.set_down02_list()
+            self.set_up30_list()
+            self.set_up31_list()
+            self.set_up32_list()
+            self.set_down03_list()
+            self.set_down13_list()
+            self.set_down23_list()
+            if self.num_sites > 1:
+                self.set_exchange_list_K1()
+                self.set_exchange_list_L1()
+                self.set_exchange_list_L2()
+                self.set_exchange_list_L3()
+                self.set_exchange_list_M0()
+                self.set_exchange_list_M1()
+                self.set_exchange_list_N0()
 
         ## Make Hamiltonian (total and by manifold)
 
@@ -744,6 +822,25 @@ class Polymer:
     def set_down02_list(self):
         self.down02_list = self.make_single_operator_list(self.down02)
 
+    # 4LS-only single-operator lists
+    def set_up30_list(self):
+        self.up30_list = self.make_single_operator_list(self.up30)
+
+    def set_up31_list(self):
+        self.up31_list = self.make_single_operator_list(self.up31)
+
+    def set_up32_list(self):
+        self.up32_list = self.make_single_operator_list(self.up32)
+
+    def set_down03_list(self):
+        self.down03_list = self.make_single_operator_list(self.down03)
+
+    def set_down13_list(self):
+        self.down13_list = self.make_single_operator_list(self.down13)
+
+    def set_down23_list(self):
+        self.down23_list = self.make_single_operator_list(self.down23)
+
     def set_down_list(self):
         self.down_list = self.make_single_operator_list(self.down)
 
@@ -761,6 +858,39 @@ class Polymer:
 
     def set_exchange_list_C(self):
         self.exchange_list_C = self.make_multi_operator_list([self.up21, self.down12])  # c_dagger * c
+
+    # K1 and 4LS-only exchange lists
+    def set_exchange_list_K1(self):
+        self.exchange_list_K1 = self.make_multi_operator_list([self.up20, self.down02])  # b†_i b_j
+
+    def set_exchange_list_L1(self):
+        self.exchange_list_L1 = self.make_multi_operator_list([self.up32, self.down01])  # q†_i a_j
+
+    def set_exchange_list_L2(self):
+        self.exchange_list_L2 = self.make_multi_operator_list([self.up31, self.down02])  # p†_i b_j
+
+    def set_exchange_list_L3(self):
+        self.exchange_list_L3 = self.make_multi_operator_list([self.up30, self.down03])  # d†_i d_j
+
+    def set_exchange_list_M0(self):
+        self.exchange_list_M0 = self.make_multi_operator_list([self.up32, self.down12])  # q†_i c_j
+
+    def set_exchange_list_M1(self):
+        self.exchange_list_M1 = self.make_multi_operator_list([self.up31, self.down13])  # p†_i p_j
+
+    def set_exchange_list_N0(self):
+        self.exchange_list_N0 = self.make_multi_operator_list([self.up32, self.down23])  # q†_i q_j
+
+    def _parse_coupling_dict(self, keys, site_couplings):
+        """Parse a dict of coupling matrices into lists of upper-triangle values."""
+        result = []
+        zero_mat = [[0.0] * self.num_sites for _ in range(self.num_sites)]
+        for key in keys:
+            mat = site_couplings.get(key, zero_mat)
+            lst = [mat[i][j] for i in range(self.num_sites)
+                   for j in range(i + 1, self.num_sites)]
+            result.append(lst)
+        return result
 
     def set_mono_H_list(self):
         self.mono_list = self.make_single_operator_list(self.H_i)
@@ -909,9 +1039,60 @@ class Polymer:
                 self.H3 += self.L_list[i] * self.exchange_list_C[i]
                 self.H3 += np.conjugate(self.L_list[i]) * self.exchange_list_C[i].T
 
+            for i in range(len(self.K1_list)):
+                self.H2 += self.K1_list[i] * self.exchange_list_K1[i]
+                self.H2 += np.conjugate(self.K1_list[i]) * self.exchange_list_K1[i].T
+
             electronic_hamiltonian = self.H0 + self.H1 + self.H2 + self.H3
 
             return electronic_hamiltonian
+
+        if self.N == 4:
+            self.H_i = []
+            H_coup = np.zeros((self.H_dim, self.H_dim))
+
+            for i in range(self.num_sites):
+                self.mono_H = np.zeros((self.N, self.N))
+                self.mono_H[1][1] = self.energies[i]
+                self.mono_H[2][2] = self.double_energies[i]
+                self.mono_H[3][3] = self.triple_energies[i]
+                self.H_i.append(self.mono_H)
+
+            self.HI = self.make_HI_i(self.H_i)
+            self.H0 = np.zeros((self.H_dim, self.H_dim))
+            for i in range(len(self.HI)):
+                self.H0 += self.HI[i]
+
+            def _add_coupling(H, coupling_list, exchange_list):
+                for i, c in enumerate(coupling_list):
+                    H += c * exchange_list[i]
+                    H += np.conjugate(c) * exchange_list[i].T
+
+            # J: a†_i a_j
+            _add_coupling(H_coup, self.J_list, self.exchange_list)
+            # K: c†_i a_j + h.c. (exchange_list_G + exchange_list_GG.T combined)
+            for i in range(len(self.K_list)):
+                H_coup += self.K_list[i] * (self.exchange_list_G[i] + self.exchange_list_GG[i].T)
+                H_coup += np.conjugate(self.K_list[i]) * (self.exchange_list_G[i].T + self.exchange_list_GG[i])
+            # K1: b†_i b_j
+            if self.num_sites > 1:
+                _add_coupling(H_coup, self.K1_list, self.exchange_list_K1)
+                # L: c†_i c_j
+                _add_coupling(H_coup, self.L_list, self.exchange_list_C)
+                # L1: q†_i a_j
+                _add_coupling(H_coup, self.L1_list, self.exchange_list_L1)
+                # L2: p†_i b_j
+                _add_coupling(H_coup, self.L2_list, self.exchange_list_L2)
+                # L3: d†_i d_j
+                _add_coupling(H_coup, self.L3_list, self.exchange_list_L3)
+                # M0: q†_i c_j
+                _add_coupling(H_coup, self.M0_list, self.exchange_list_M0)
+                # M1: p†_i p_j
+                _add_coupling(H_coup, self.M1_list, self.exchange_list_M1)
+                # N0: q†_i q_j
+                _add_coupling(H_coup, self.N0_list, self.exchange_list_N0)
+
+            return self.H0 + H_coup
 
     def set_electronic_hamiltonian(self):
         self.electronic_hamiltonian = self.make_electronic_hamiltonian()
@@ -936,7 +1117,7 @@ class Polymer:
     def set_manifold_eigensystems(self):
         self.electronic_eigenvalues_by_manifold = []
         self.electronic_eigenvectors_by_manifold = []
-        for i in range(self.num_sites + 1):
+        for i in range(self.maximum_manifold + 1):
             e, v = self.make_manifold_eigensystem(i)
             self.electronic_eigenvalues_by_manifold.append(e)
             self.electronic_eigenvectors_by_manifold.append(v)
@@ -950,7 +1131,7 @@ class Polymer:
         H = self.electronic_hamiltonian
         eigvecs = np.zeros(H.shape)
         d = np.zeros(H.shape)
-        for i in range(self.num_sites + 1):
+        for i in range(self.maximum_manifold + 1):
             e, v = self.get_eigensystem_by_manifold(i)
             if i == 1:
                 self.exciton_energies = e
@@ -967,17 +1148,31 @@ class Polymer:
 
     ### Tools for making the dipole operator
 
+    def _dipole_components_4LS(self, site_idx, pol_idx):
+        """Return the 6 per-site dipole amplitudes for a 4LS site.
+
+        Handles both the 3-vector shortcut (shape ..., 3, 3) and the full
+        6-vector form (shape ..., 6, 3).  For the shortcut, d_gf=d_gh=d_eh=0.
+        """
+        d = self.dipoles[site_idx, :, pol_idx]  # shape (3,) or (6,)
+        d_ge = d[0]
+        d_ef = d[1]
+        d_fh = d[2]
+        d_gf = d[3] if len(d) > 3 else 0.0
+        d_gh = d[4] if len(d) > 4 else 0.0
+        d_eh = d[5] if len(d) > 5 else 0.0
+        return d_ge, d_ef, d_fh, d_gf, d_gh, d_eh
+
     def make_mu_site_basis(self, pol):
+        pol_idx = {'x': 0, 'y': 1, 'z': 2}[pol]
         if self.N == 2:
-            pol_dict = {'x': 0, 'y': 1, 'z': 2}
-            d = self.dipoles[:, pol_dict[pol]]
+            d = self.dipoles[:, pol_idx]
             self.mu = d[0] * (self.up_list[0] + self.down_list[0])
             for i in range(1, len(self.up_list)):
                 self.mu += d[i] * (self.up_list[i] + self.down_list[i])
 
         elif self.N == 3:
-            pol_dict = {'x': 0, 'y': 1, 'z': 2}
-            d = self.dipoles[..., pol_dict[pol]]
+            d = self.dipoles[..., pol_idx]
             self.mu_10_01 = d[0,0] * (self.up10_list[0].copy() + self.down01_list[0].copy())
             self.mu_21_12 = d[0,1] * (self.up21_list[0].copy() + self.down12_list[0].copy())
             self.mu_20_02 = d[0,2] * (self.up20_list[0].copy() + self.down02_list[0].copy())
@@ -987,30 +1182,39 @@ class Polymer:
                 self.mu_20_02 += d[i,2] * (self.up20_list[i] + self.down02_list[i])
             self.mu = self.mu_10_01 + self.mu_21_12 + self.mu_20_02
 
-    def make_mu_dict_site_basis(self):
-        if self.N == 2:
-            self.mu_dict = dict()
-            for pol in self.pols:
-                self.make_mu_site_basis(pol)
-                self.mu_dict[pol] = self.mu.copy()
+        elif self.N == 4:
+            d_ge, d_ef, d_fh, d_gf, d_gh, d_eh = self._dipole_components_4LS(0, pol_idx)
+            self.mu = (d_ge * (self.up10_list[0] + self.down01_list[0])
+                       + d_ef * (self.up21_list[0] + self.down12_list[0])
+                       + d_fh * (self.up32_list[0] + self.down23_list[0])
+                       + d_gf * (self.up20_list[0] + self.down02_list[0])
+                       + d_gh * (self.up30_list[0] + self.down03_list[0])
+                       + d_eh * (self.up31_list[0] + self.down13_list[0]))
+            for i in range(1, self.num_sites):
+                d_ge, d_ef, d_fh, d_gf, d_gh, d_eh = self._dipole_components_4LS(i, pol_idx)
+                self.mu += (d_ge * (self.up10_list[i] + self.down01_list[i])
+                            + d_ef * (self.up21_list[i] + self.down12_list[i])
+                            + d_fh * (self.up32_list[i] + self.down23_list[i])
+                            + d_gf * (self.up20_list[i] + self.down02_list[i])
+                            + d_gh * (self.up30_list[i] + self.down03_list[i])
+                            + d_eh * (self.up31_list[i] + self.down13_list[i]))
 
-        elif self.N == 3 :
-            self.mu_dict = dict()
-            for pol in self.pols:
-                self.make_mu_site_basis(pol)
-                self.mu_dict[pol] = self.mu.copy()
+    def make_mu_dict_site_basis(self):
+        self.mu_dict = dict()
+        for pol in self.pols:
+            self.make_mu_site_basis(pol)
+            self.mu_dict[pol] = self.mu.copy()
 
     def make_mu_up_site_basis(self, pol):
+        pol_idx = {'x': 0, 'y': 1, 'z': 2}[pol]
         if self.N == 2:
-            pol_dict = {'x': 0, 'y': 1, 'z': 2}
-            d = self.dipoles[:, pol_dict[pol]]
+            d = self.dipoles[:, pol_idx]
             self.mu_ket_up = self.up_list[0].copy() * d[0]
             for i in range(1, len(self.up_list)):
                 self.mu_ket_up += self.up_list[i] * d[i]
 
         elif self.N == 3:
-            pol_dict = {'x': 0, 'y': 1, 'z': 2}
-            d = self.dipoles[..., pol_dict[pol]]
+            d = self.dipoles[..., pol_idx]
             self.mu_ket_up10 = self.up10_list[0].copy() * d[0, 0]
             self.mu_ket_up21 = self.up21_list[0].copy() * d[0, 1]
             self.mu_ket_up20 = self.up20_list[0].copy() * d[0, 2]
@@ -1020,17 +1224,28 @@ class Polymer:
                 self.mu_ket_up20 += self.up20_list[i] * d[i, 2]
             self.mu_ket_up = self.mu_ket_up10 + self.mu_ket_up21 + self.mu_ket_up20
 
+        elif self.N == 4:
+            d_ge, d_ef, d_fh, d_gf, d_gh, d_eh = self._dipole_components_4LS(0, pol_idx)
+            self.mu_ket_up = (d_ge * self.up10_list[0].copy()
+                              + d_ef * self.up21_list[0].copy()
+                              + d_fh * self.up32_list[0].copy()
+                              + d_gf * self.up20_list[0].copy()
+                              + d_gh * self.up30_list[0].copy()
+                              + d_eh * self.up31_list[0].copy())
+            for i in range(1, self.num_sites):
+                d_ge, d_ef, d_fh, d_gf, d_gh, d_eh = self._dipole_components_4LS(i, pol_idx)
+                self.mu_ket_up += (d_ge * self.up10_list[i]
+                                   + d_ef * self.up21_list[i]
+                                   + d_fh * self.up32_list[i]
+                                   + d_gf * self.up20_list[i]
+                                   + d_gh * self.up30_list[i]
+                                   + d_eh * self.up31_list[i])
+
     def make_mu_up_dict_site_basis(self):
-        if self.N == 2:
-            self.mu_up_dict = dict()
-            for pol in self.pols:
-                self.make_mu_up_site_basis(pol)
-                self.mu_up_dict[pol] = self.mu_ket_up.copy()
-        if self.N == 3:
-            self.mu_up_dict = dict()
-            for pol in self.pols:
-                self.make_mu_up_site_basis(pol)
-                self.mu_up_dict[pol] = self.mu_ket_up.copy()
+        self.mu_up_dict = dict()
+        for pol in self.pols:
+            self.make_mu_up_site_basis(pol)
+            self.mu_up_dict[pol] = self.mu_ket_up.copy()
 
 
     def make_mu_up_3d(self):

--- a/ufss/HLG/make_simple_systems.py
+++ b/ufss/HLG/make_simple_systems.py
@@ -152,3 +152,89 @@ def make_3LS(folder_name,omega0,tau_deph,kT,secular = True,tau_relax = 'auto',
         yaml.dump(params,new_file)
 
     run(folder_name,conserve_memory=conserve_memory)
+
+def make_4LS(folder_name, omega0, tau_deph, kT, secular=True, tau_relax='auto',
+             conserve_memory=False, omega21='auto', omega32='auto',
+             dipole12='auto', dipole23='auto',
+             tau_deph2='auto', tau_deph3='auto',
+             tau_relax2='auto', tau_relax3='auto'):
+    """Makes a single-site 4LS (four-level system).
+
+    Args:
+        folder_name (str): folder for the calculations
+        omega0 (float): energy of the g<->e transition (rad/fs)
+        tau_deph (float): dephasing time for the g<->e transition (fs)
+        kT (float): thermal energy (rad/fs)
+    """
+    if tau_relax == 'auto':
+        tau_relax = tau_deph * 1000
+    if omega21 == 'auto':
+        omega21 = 2 * omega0
+    if omega32 == 'auto':
+        omega32 = 3 * omega0
+    if dipole12 == 'auto':
+        dipole12 = [1, 0, 0]
+    if dipole23 == 'auto':
+        dipole23 = [1, 0, 0]
+    if tau_deph2 == 'auto':
+        tau_deph2 = tau_deph
+    if tau_deph3 == 'auto':
+        tau_deph3 = tau_deph
+    if tau_relax2 == 'auto':
+        tau_relax2 = tau_relax
+    if tau_relax3 == 'auto':
+        tau_relax3 = tau_relax
+
+    taud  = float(tau_deph  * omega0)
+    taud2 = float(tau_deph2 * omega0)
+    taud3 = float(tau_deph3 * omega0)
+    taur  = float(tau_relax  * omega0)
+    taur2 = float(tau_relax2 * omega0)
+    taur3 = float(tau_relax3 * omega0)
+    kT = float(kT / omega0)
+
+    site_energies = [[1, float(omega21 / omega0), float(omega32 / omega0)]]
+    site_couplings = {}
+    dipoles = [[[1, 0, 0], dipole12, dipole23]]
+
+    os.makedirs(folder_name, exist_ok=True)
+
+    site_bath  = {'dephasing_rate': 1/taud,  'relaxation_rate': 0,
+                  'temperature': kT, 'spectrum_type': 'white-noise'}
+    site_bath2 = {'dephasing_rate': 1/taud2, 'relaxation_rate': 0,
+                  'temperature': kT, 'spectrum_type': 'white-noise'}
+    site_bath3 = {'dephasing_rate': 1/taud3, 'relaxation_rate': 0,
+                  'temperature': kT, 'spectrum_type': 'white-noise'}
+    vibration_bath = site_bath
+    relax_bath  = {'dephasing_rate': 0, 'relaxation_rate': 1/taur,
+                   'temperature': kT, 'spectrum_type': 'white-noise'}
+    relax_bath2 = {'dephasing_rate': 0, 'relaxation_rate': 1/taur2,
+                   'temperature': kT, 'spectrum_type': 'white-noise'}
+    relax_bath3 = {'dephasing_rate': 0, 'relaxation_rate': 1/taur3,
+                   'temperature': kT, 'spectrum_type': 'white-noise'}
+
+    Redfield_bath = {
+        'secular': secular,
+        'site_bath': site_bath,
+        'site_bath2': site_bath2,
+        'site_bath3': site_bath3,
+        'vibration_bath': vibration_bath,
+        'site_internal_conversion_bath': relax_bath,
+        'site_internal_conversion_bath21': relax_bath2,
+        'site_internal_conversion_bath32': relax_bath3,
+    }
+
+    params = {
+        'site_energies': site_energies,
+        'site_couplings': site_couplings,
+        'dipoles': dipoles,
+        'truncation_size': 1,
+        'vibrations': [],
+        'bath': Redfield_bath,
+        'maximum_manifold': 4,
+    }
+
+    with open(os.path.join(folder_name, 'simple_params.yaml'), 'w+') as new_file:
+        yaml.dump(params, new_file)
+
+    run(folder_name, conserve_memory=conserve_memory)


### PR DESCRIPTION
Untested (by me), though Claude added some tests. Goal is to make a 4LS generator in the Polymer class in the HLG. 

There are now many more couplings, and we use the notation
J (1 exciton couplings)
K (2 exciton couplings)
L (3 exciton couplings)
M (4 exciton couplings)
N (5 exciton couplings)
with J, K, L the same as for 3LS, for backward compatibility, and new terms K1, L1, L2, L3, M0, M1, N0 added according to
```
Name	Operator	Min. manifold	
J	a†_i · a_j	                 1 — singly excited	
K	c†_i · a_j + h.c.	2 — doubly excited
K1	b†_i · b_j	                 2 — doubly excited	
L	c†_i · c_j	                 3 — triply excited	
L1	q†_i · a_j + h.c.	3 — triply excited	
L2	p†_i · b_j + h.c.	3 — triply excited	
L3	d†_i · d_j	                 3 — triply excited	
M0	q†_i · c_j + h.c.	4 — quadruply excited	
M1	p†_i · p_j	                 4 — quadruply excited	
N0	q†_i · q_j	                 5 — quintuply excited	
```
for annihilation operators a,b,c (as for 3LS) and new operators d, p, q that are |g><h|, |e><h|, and |f><h|, respectively, for the 4th level |h>.

Parameters J, K, L, etc can now be entered either as a list or as a dict, also for 3LS.