### PR TITLE
Extend Redfield Liouvillians and Hamiltonians to support 4LS

### DIFF
--- a/tests/unit/test_polymer_hamiltonians.py
+++ b/tests/unit/test_polymer_hamiltonians.py
@@ -53,10 +53,12 @@ import numpy as np
 import pytest
 import sys
 import os
+import tempfile
+import yaml
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
-from ufss.HLG.Hamiltonians import Polymer
+from ufss.HLG.Hamiltonians import Polymer, PolymerVibrations
 
 
 # ---------------------------------------------------------------------------
@@ -537,3 +539,209 @@ class Test4LS:
             make_4LS(tmpdir, omega0=1.0, tau_deph=100.0, kT=0.1)
             assert os.path.exists(os.path.join(tmpdir, 'closed', 'H.npz'))
             assert os.path.exists(os.path.join(tmpdir, 'closed', 'mu.npz'))
+
+
+# ---------------------------------------------------------------------------
+# Helpers for PolymerVibrations tests
+# ---------------------------------------------------------------------------
+
+def _write_params_yaml(tmpdir, params):
+    """Write a params dict to params.yaml in tmpdir, return the path."""
+    path = os.path.join(tmpdir, 'params.yaml')
+    with open(path, 'w') as f:
+        yaml.dump(params, f)
+    return path
+
+
+def _minimal_vib_mode(site_label, n_occ):
+    """Return a minimal harmonic vib-mode dict with n_occ electronic occupations."""
+    return {
+        'site_label': site_label,
+        'omega_g': 0.15,
+        'displacement': [0.1 * i for i in range(n_occ)],
+        'kinetic':      [[1]] * n_occ,
+        'potential':    [[1]] * n_occ,
+        'reorganization': [0.0] + [-0.01] * (n_occ - 1),
+    }
+
+
+def _params_2LS(truncation=3):
+    """Minimal single-site 2LS params (post-conversion format).
+    N=2 uses a flat list of scalar energies (not a list of lists).
+    Dipoles are shape (num_sites, 3) — one vector per site.
+    """
+    return {
+        'RWA': True,
+        'initial truncation size': truncation,
+        'site_energies': [1.0],          # scalar per site → N=2
+        'site_couplings': [],
+        'dipoles': [[1.0, 0.0, 0.0]],   # (num_sites, 3)
+        'vibrations': [_minimal_vib_mode(0, 2)],
+    }
+
+
+def _params_3LS(truncation=3):
+    """Minimal single-site 3LS params (post-conversion format)."""
+    return {
+        'RWA': True,
+        'initial truncation size': truncation,
+        'site_energies': [[1.0, 2.5]],
+        'site_couplings': {},
+        'dipoles': [[[1.0, 0.0, 0.0], [0.5, 0.0, 0.0], [0.0, 0.0, 0.0]]],
+        'vibrations': [_minimal_vib_mode(0, 3)],
+    }
+
+
+def _params_4LS(truncation=3):
+    """Minimal single-site 4LS params (post-conversion format)."""
+    return {
+        'RWA': True,
+        'initial truncation size': truncation,
+        'site_energies': [[1.0, 2.5, 4.0]],
+        'site_couplings': {},
+        'dipoles': [[[1.0, 0.0, 0.0], [0.5, 0.0, 0.0], [0.3, 0.0, 0.0]]],
+        'vibrations': [_minimal_vib_mode(0, 4)],
+    }
+
+
+# ---------------------------------------------------------------------------
+# TestPolymerVibrations
+# ---------------------------------------------------------------------------
+
+class TestPolymerVibrations:
+
+    # --- 2LS ---
+
+    def test_2LS_runs(self):
+        """PolymerVibrations works for a single-site 2LS."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_params_yaml(tmpdir, _params_2LS())
+            pv = PolymerVibrations(path)
+            assert pv.total_hamiltonian.ndim == 2
+            assert pv.total_hamiltonian.shape[0] == pv.total_hamiltonian.shape[1]
+
+    def test_2LS_H_saved(self):
+        """H.npz is written to the closed/ subdirectory for 2LS."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_params_yaml(tmpdir, _params_2LS())
+            PolymerVibrations(path)
+            assert os.path.exists(os.path.join(tmpdir, 'closed', 'H.npz'))
+
+    def test_2LS_no_doubly_occupied_vibrations(self):
+        """For N=2, doubly_occupied_vibrations should not be set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_params_yaml(tmpdir, _params_2LS())
+            pv = PolymerVibrations(path)
+            assert not hasattr(pv, 'doubly_occupied_vibrations')
+
+    # --- 3LS ---
+
+    def test_3LS_runs(self):
+        """PolymerVibrations works for a single-site 3LS."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_params_yaml(tmpdir, _params_3LS())
+            pv = PolymerVibrations(path)
+            assert pv.total_hamiltonian.ndim == 2
+            assert pv.total_hamiltonian.shape[0] == pv.total_hamiltonian.shape[1]
+
+    def test_3LS_H_saved(self):
+        """H.npz is written to the closed/ subdirectory for 3LS."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_params_yaml(tmpdir, _params_3LS())
+            PolymerVibrations(path)
+            assert os.path.exists(os.path.join(tmpdir, 'closed', 'H.npz'))
+
+    def test_3LS_doubly_occupied_vibrations_populated(self):
+        """For N=3, doubly_occupied_vibrations should be a non-empty list."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_params_yaml(tmpdir, _params_3LS())
+            pv = PolymerVibrations(path)
+            assert hasattr(pv, 'doubly_occupied_vibrations')
+            assert len(pv.doubly_occupied_vibrations) == pv.num_vibrations
+
+    def test_3LS_vibrational_hamiltonian_nonzero(self):
+        """The vibrational part of the Hamiltonian should be nonzero for 3LS."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_params_yaml(tmpdir, _params_3LS())
+            pv = PolymerVibrations(path)
+            assert np.any(pv.vibrational_hamiltonian != 0)
+
+    def test_3LS_no_triply_occupied_vibrations(self):
+        """For N=3, triply_occupied_vibrations should not be set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_params_yaml(tmpdir, _params_3LS())
+            pv = PolymerVibrations(path)
+            assert not hasattr(pv, 'triply_occupied_vibrations')
+
+    def test_3LS_hamiltonian_is_hermitian(self):
+        """Total Hamiltonian must be Hermitian for 3LS."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_params_yaml(tmpdir, _params_3LS())
+            pv = PolymerVibrations(path)
+            H = pv.total_hamiltonian
+            np.testing.assert_allclose(H, H.T.conj(), atol=1e-12)
+
+    # --- 4LS ---
+
+    def test_4LS_runs(self):
+        """PolymerVibrations works for a single-site 4LS."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_params_yaml(tmpdir, _params_4LS())
+            pv = PolymerVibrations(path)
+            assert pv.total_hamiltonian.ndim == 2
+            assert pv.total_hamiltonian.shape[0] == pv.total_hamiltonian.shape[1]
+
+    def test_4LS_H_saved(self):
+        """H.npz is written to the closed/ subdirectory for 4LS."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_params_yaml(tmpdir, _params_4LS())
+            PolymerVibrations(path)
+            assert os.path.exists(os.path.join(tmpdir, 'closed', 'H.npz'))
+
+    def test_4LS_triply_occupied_vibrations_populated(self):
+        """For N=4, triply_occupied_vibrations should be a non-empty list."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_params_yaml(tmpdir, _params_4LS())
+            pv = PolymerVibrations(path)
+            assert hasattr(pv, 'triply_occupied_vibrations')
+            assert len(pv.triply_occupied_vibrations) == pv.num_vibrations
+
+    def test_4LS_doubly_occupied_vibrations_populated(self):
+        """For N=4, doubly_occupied_vibrations should also be populated."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_params_yaml(tmpdir, _params_4LS())
+            pv = PolymerVibrations(path)
+            assert hasattr(pv, 'doubly_occupied_vibrations')
+            assert len(pv.doubly_occupied_vibrations) == pv.num_vibrations
+
+    def test_4LS_vibrational_hamiltonian_nonzero(self):
+        """The vibrational part of the Hamiltonian should be nonzero for 4LS."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_params_yaml(tmpdir, _params_4LS())
+            pv = PolymerVibrations(path)
+            assert np.any(pv.vibrational_hamiltonian != 0)
+
+    def test_4LS_hamiltonian_is_hermitian(self):
+        """Total Hamiltonian must be Hermitian for 4LS."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_params_yaml(tmpdir, _params_4LS())
+            pv = PolymerVibrations(path)
+            H = pv.total_hamiltonian
+            np.testing.assert_allclose(H, H.T.conj(), atol=1e-12)
+
+    def test_4LS_hilbert_space_larger_than_3LS(self):
+        """4LS vibronic Hilbert space must be larger than the equivalent 3LS one."""
+        with tempfile.TemporaryDirectory() as d3:
+            pv3 = PolymerVibrations(_write_params_yaml(d3, _params_3LS()))
+            with tempfile.TemporaryDirectory() as d4:
+                pv4 = PolymerVibrations(_write_params_yaml(d4, _params_4LS()))
+        assert pv4.total_hamiltonian.shape[0] > pv3.total_hamiltonian.shape[0]
+
+    def test_4LS_triply_occupied_contributes_to_hamiltonian(self):
+        """Triply-occupied vib term should contribute to the total Hamiltonian."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_params_yaml(tmpdir, _params_4LS())
+            pv = PolymerVibrations(path)
+            # Sum of triply-occupied vibrational terms
+            trip_sum = sum(pv.triply_occupied_vibrations)
+            assert np.any(trip_sum != 0)

--- a/ufss/HLG/Hamiltonians.py
+++ b/ufss/HLG/Hamiltonians.py
@@ -639,6 +639,7 @@ class Polymer:
         # For 4LS
         if self.N == 4:
             self.set_doubly_occupied_list()
+            self.set_triply_occupied_list()
             self.set_exchange_list_G()
             self.set_exchange_list_GG()
             self.set_exchange_list_C()
@@ -800,6 +801,9 @@ class Polymer:
 
     def set_doubly_occupied_list(self):
         self.doubly_occupied_list = self.make_single_operator_list(self.occupied_2)
+
+    def set_triply_occupied_list(self):
+        self.triply_occupied_list = self.make_single_operator_list(self.occupied_3)
 
     def set_up_list(self):
         self.up_list = self.make_single_operator_list(self.up)

--- a/ufss/HLG/Hamiltonians.py
+++ b/ufss/HLG/Hamiltonians.py
@@ -1391,14 +1391,18 @@ class PolymerVibrations():
     def add_vibrations(self):
         v0 = self.empty_vibrations
         v1 = self.occupied_vibrations
-        if self.Polymer.N == 3:
+        if self.Polymer.N >= 3:
             v2 = self.doubly_occupied_vibrations
+        if self.Polymer.N >= 4:
+            v3 = self.triply_occupied_vibrations
         self.vibrational_hamiltonian = np.zeros(self.total_hamiltonian.shape)
         for i in range(len(v0)):
             self.vibrational_hamiltonian += v0[i]
             self.vibrational_hamiltonian += v1[i]
-            if self.Polymer.N == 3:
+            if self.Polymer.N >= 3:
                 self.vibrational_hamiltonian += v2[i]
+            if self.Polymer.N >= 4:
+                self.vibrational_hamiltonian += v3[i]
 
         self.total_hamiltonian = self.total_hamiltonian + self.vibrational_hamiltonian
 
@@ -1423,8 +1427,11 @@ class PolymerVibrations():
         self.num_vibrations = len(emp_vibs)
         occ_vibs = [self.construct_vibrational_hamiltonian(mode_dict,1)
                     for mode_dict in vibration_params]
-        if self.Polymer.N == 3:
+        if self.Polymer.N >= 3:
             doub_occ_vibs = [self.construct_vibrational_hamiltonian(mode_dict,2)
+                        for mode_dict in vibration_params]
+        if self.Polymer.N >= 4:
+            trip_occ_vibs = [self.construct_vibrational_hamiltonian(mode_dict,3)
                         for mode_dict in vibration_params]
 
         if self.occupation_num_mask:
@@ -1437,28 +1444,37 @@ class PolymerVibrations():
             self.vibrational_identity = np.eye(N**nv)
         empty_vibrations = self.kron_up_vibrations(emp_vibs)
         occupied_vibrations = self.kron_up_vibrations(occ_vibs)
-        if self.Polymer.N == 3:
+        if self.Polymer.N >= 3:
             doubly_occupied_vibrations = self.kron_up_vibrations(doub_occ_vibs)
+        if self.Polymer.N >= 4:
+            triply_occupied_vibrations = self.kron_up_vibrations(trip_occ_vibs)
 
         self.empty_vibrations = []
         self.occupied_vibrations = []
-        if self.Polymer.N == 3:
+        if self.Polymer.N >= 3:
             self.doubly_occupied_vibrations = []
-        
+        if self.Polymer.N >= 4:
+            self.triply_occupied_vibrations = []
+
         for i in range(self.num_vibrations):
             site_index = vibration_params[i]['site_label']
             empty = self.Polymer.empty_list[site_index]
             empty = self.Polymer.extract_electronic_subspace(empty,0,self.maximum_manifold)
             occupied = self.Polymer.occupied_list[site_index]
             occupied = self.Polymer.extract_electronic_subspace(occupied,0,self.maximum_manifold)
-            if self.Polymer.N == 3:
+            if self.Polymer.N >= 3:
                 doubly_occupied = self.Polymer.doubly_occupied_list[site_index]
                 doubly_occupied = self.Polymer.extract_electronic_subspace(doubly_occupied,0,self.maximum_manifold)
-            
+            if self.Polymer.N >= 4:
+                triply_occupied = self.Polymer.triply_occupied_list[site_index]
+                triply_occupied = self.Polymer.extract_electronic_subspace(triply_occupied,0,self.maximum_manifold)
+
             self.empty_vibrations.append(np.kron(empty,empty_vibrations[i]))
             self.occupied_vibrations.append(np.kron(occupied,occupied_vibrations[i]))
-            if self.Polymer.N == 3:
+            if self.Polymer.N >= 3:
                 self.doubly_occupied_vibrations.append(np.kron(doubly_occupied,doubly_occupied_vibrations[i]))
+            if self.Polymer.N >= 4:
+                self.triply_occupied_vibrations.append(np.kron(triply_occupied,triply_occupied_vibrations[i]))
 
     def kron_up_vibrations(self,vibrations_list):
         n = self.num_vibrations

--- a/ufss/HLG/Redfield_Liouvillians.py
+++ b/ufss/HLG/Redfield_Liouvillians.py
@@ -226,6 +226,12 @@ class RedfieldConstructor:
                     spec_density = self.make_spectral_density(self.params['bath']['site_bath2'][bath2_option])
                     self.SD['site_bath2'].append(spec_density)
 
+            if 'site_bath3' in self.params['bath']:
+                self.SD['site_bath3'] = []
+                for n in range(self.PolyVib.Polymer.num_sites):
+                    bath3_option = self.params['bath']['site_bath3_option'][n]
+                    spec_density = self.make_spectral_density(self.params['bath']['site_bath3'][bath3_option])
+                    self.SD['site_bath3'].append(spec_density)
 
             if self.num_vibrations > 0 :
                 if 'vibration_bath' in self.params['bath'].keys():
@@ -247,6 +253,21 @@ class RedfieldConstructor:
 
             try:
                 self.SD['site_internal_conversion_bath20'] = self.make_spectral_density(self.params['bath']['site_internal_conversion_bath20'])
+            except KeyError:
+                pass
+
+            try:
+                self.SD['site_internal_conversion_bath32'] = self.make_spectral_density(self.params['bath']['site_internal_conversion_bath32'])
+            except KeyError:
+                pass
+
+            try:
+                self.SD['site_internal_conversion_bath31'] = self.make_spectral_density(self.params['bath']['site_internal_conversion_bath31'])
+            except KeyError:
+                pass
+
+            try:
+                self.SD['site_internal_conversion_bath30'] = self.make_spectral_density(self.params['bath']['site_internal_conversion_bath30'])
             except KeyError:
                 pass
 
@@ -272,12 +293,32 @@ class RedfieldConstructor:
                 pass
 
             try:
+                self.SD['site_bath3'] = self.make_spectral_density(self.params['bath']['site_bath3'])
+            except KeyError:
+                pass
+
+            try:
                 self.SD['site_internal_conversion_bath21'] = self.make_spectral_density(self.params['bath']['site_internal_conversion_bath21'])
             except KeyError:
                 pass
 
             try:
                 self.SD['site_internal_conversion_bath20'] = self.make_spectral_density(self.params['bath']['site_internal_conversion_bath20'])
+            except KeyError:
+                pass
+
+            try:
+                self.SD['site_internal_conversion_bath32'] = self.make_spectral_density(self.params['bath']['site_internal_conversion_bath32'])
+            except KeyError:
+                pass
+
+            try:
+                self.SD['site_internal_conversion_bath31'] = self.make_spectral_density(self.params['bath']['site_internal_conversion_bath31'])
+            except KeyError:
+                pass
+
+            try:
+                self.SD['site_internal_conversion_bath30'] = self.make_spectral_density(self.params['bath']['site_internal_conversion_bath30'])
             except KeyError:
                 pass
 
@@ -404,7 +445,7 @@ class RedfieldConstructor:
                 Y2 += self.make_dissipation_tensor(P_n, manifold_key, spectral_density)
 
             # create the electronic dissipation tensor for doubly-excited site
-            if self.N == 3:
+            if self.N >= 3:
                 if 'site_bath2' in self.params['bath']:
                     for n in range(self.PolyVib.Polymer.num_sites):
                         spectral_density = self.SD['site_bath2'][n]
@@ -414,6 +455,19 @@ class RedfieldConstructor:
                         P_n2 = np.kron(P_n2, self.PolyVib.vibrational_identity)
 
                         Y2 += self.make_dissipation_tensor(P_n2, manifold_key, spectral_density)
+
+            # create the electronic dissipation tensor for triply-excited site
+            if self.N >= 4:
+                if 'site_bath3' in self.params['bath']:
+                    for n in range(self.PolyVib.Polymer.num_sites):
+                        spectral_density = self.SD['site_bath3'][n]
+                        P_n3 = self.PolyVib.Polymer.triply_occupied_list[n]
+                        P_n3 = self.extract_electronic_operator(P_n3, manifold_key)
+
+                        P_n3 = np.kron(P_n3, self.PolyVib.vibrational_identity)
+
+                        Y2 += self.make_dissipation_tensor(P_n3, manifold_key, spectral_density)
+
         else :
             spectral_density = self.SD['site_bath']
             size = self.eigenvalues[manifold_key].size
@@ -428,7 +482,7 @@ class RedfieldConstructor:
                 Y2 += self.make_dissipation_tensor(P_n,manifold_key,spectral_density)
 
             # create the electronic dissipation tensor for doubly-excited site
-            if self.N == 3:
+            if self.N >= 3:
                 if 'site_bath2' in self.params['bath']:
                     spectral_density = self.SD['site_bath2']
                     for n in range(self.PolyVib.Polymer.num_sites):
@@ -438,6 +492,18 @@ class RedfieldConstructor:
                         P_n2 = np.kron(P_n2, self.PolyVib.vibrational_identity)
 
                         Y2 += self.make_dissipation_tensor(P_n2,manifold_key,spectral_density)
+
+            # create the electronic dissipation tensor for triply-excited site
+            if self.N >= 4:
+                if 'site_bath3' in self.params['bath']:
+                    spectral_density = self.SD['site_bath3']
+                    for n in range(self.PolyVib.Polymer.num_sites):
+                        P_n3 = self.PolyVib.Polymer.triply_occupied_list[n]
+                        P_n3 = self.extract_electronic_operator(P_n3, manifold_key)
+
+                        P_n3 = np.kron(P_n3, self.PolyVib.vibrational_identity)
+
+                        Y2 += self.make_dissipation_tensor(P_n3, manifold_key, spectral_density)
 
         return Y2
 
@@ -467,7 +533,7 @@ class RedfieldConstructor:
 
             Y3 += self.make_dissipation_tensor(sigma_x_n,manifold_key,spectral_density)
 
-        if self.N == 3:
+        if self.N >= 3:
             if 'site_internal_conversion_bath21' in self.params['bath']:
                 spectral_density = self.SD['site_internal_conversion_bath21']
                 manifold_key = 'all_manifolds'
@@ -491,7 +557,44 @@ class RedfieldConstructor:
                     sigma_x_n20 = up_n20 + up_n20.T
 
                     Y3 += self.make_dissipation_tensor(sigma_x_n20, manifold_key, spectral_density)
-                
+
+        if self.N >= 4:
+            if 'site_internal_conversion_bath32' in self.params['bath']:
+                spectral_density = self.SD['site_internal_conversion_bath32']
+                manifold_key = 'all_manifolds'
+
+                for n in range(self.PolyVib.Polymer.num_sites):
+                    up_n32 = self.PolyVib.Polymer.up32_list[n]
+                    up_n32 = self.extract_electronic_operator(up_n32, manifold_key)
+                    up_n32 = np.kron(up_n32, self.PolyVib.vibrational_identity)
+                    sigma_x_n32 = up_n32 + up_n32.T
+
+                    Y3 += self.make_dissipation_tensor(sigma_x_n32, manifold_key, spectral_density)
+
+            if 'site_internal_conversion_bath31' in self.params['bath']:
+                spectral_density = self.SD['site_internal_conversion_bath31']
+                manifold_key = 'all_manifolds'
+
+                for n in range(self.PolyVib.Polymer.num_sites):
+                    up_n31 = self.PolyVib.Polymer.up31_list[n]
+                    up_n31 = self.extract_electronic_operator(up_n31, manifold_key)
+                    up_n31 = np.kron(up_n31, self.PolyVib.vibrational_identity)
+                    sigma_x_n31 = up_n31 + up_n31.T
+
+                    Y3 += self.make_dissipation_tensor(sigma_x_n31, manifold_key, spectral_density)
+
+            if 'site_internal_conversion_bath30' in self.params['bath']:
+                spectral_density = self.SD['site_internal_conversion_bath30']
+                manifold_key = 'all_manifolds'
+
+                for n in range(self.PolyVib.Polymer.num_sites):
+                    up_n30 = self.PolyVib.Polymer.up30_list[n]
+                    up_n30 = self.extract_electronic_operator(up_n30, manifold_key)
+                    up_n30 = np.kron(up_n30, self.PolyVib.vibrational_identity)
+                    sigma_x_n30 = up_n30 + up_n30.T
+
+                    Y3 += self.make_dissipation_tensor(sigma_x_n30, manifold_key, spectral_density)
+
         return Y3
 
     def make_R_from_Y(self,Y,manifold_key):
@@ -848,6 +951,13 @@ class SecularRedfieldConstructor:
                     spec_density = self.make_spectral_density(self.params['bath']['site_bath2'][bath2_option])
                     self.SD['site_bath2'].append(spec_density)
 
+            if 'site_bath3' in self.params['bath']:
+                self.SD['site_bath3'] = []
+                for n in range(self.PolyVib.Polymer.num_sites):
+                    bath3_option = self.params['bath']['site_bath3_option'][n]
+                    spec_density = self.make_spectral_density(self.params['bath']['site_bath3'][bath3_option])
+                    self.SD['site_bath3'].append(spec_density)
+
             if self.num_vibrations > 0:
                 self.SD['vibration_bath'] = self.make_spectral_density(self.params['bath']['vibration_bath'])
             try:
@@ -868,6 +978,24 @@ class SecularRedfieldConstructor:
             try:
                 self.SD['site_internal_conversion_bath20'] = self.make_spectral_density(
                     self.params['bath']['site_internal_conversion_bath20'])
+            except KeyError:
+                pass
+
+            try:
+                self.SD['site_internal_conversion_bath32'] = self.make_spectral_density(
+                    self.params['bath']['site_internal_conversion_bath32'])
+            except KeyError:
+                pass
+
+            try:
+                self.SD['site_internal_conversion_bath31'] = self.make_spectral_density(
+                    self.params['bath']['site_internal_conversion_bath31'])
+            except KeyError:
+                pass
+
+            try:
+                self.SD['site_internal_conversion_bath30'] = self.make_spectral_density(
+                    self.params['bath']['site_internal_conversion_bath30'])
             except KeyError:
                 pass
 
@@ -891,6 +1019,11 @@ class SecularRedfieldConstructor:
                 pass
 
             try:
+                self.SD['site_bath3'] = self.make_spectral_density(self.params['bath']['site_bath3'])
+            except KeyError:
+                pass
+
+            try:
                 self.SD['site_internal_conversion_bath21'] = self.make_spectral_density(
                     self.params['bath']['site_internal_conversion_bath21'])
             except KeyError:
@@ -899,6 +1032,24 @@ class SecularRedfieldConstructor:
             try:
                 self.SD['site_internal_conversion_bath20'] = self.make_spectral_density(
                     self.params['bath']['site_internal_conversion_bath20'])
+            except KeyError:
+                pass
+
+            try:
+                self.SD['site_internal_conversion_bath32'] = self.make_spectral_density(
+                    self.params['bath']['site_internal_conversion_bath32'])
+            except KeyError:
+                pass
+
+            try:
+                self.SD['site_internal_conversion_bath31'] = self.make_spectral_density(
+                    self.params['bath']['site_internal_conversion_bath31'])
+            except KeyError:
+                pass
+
+            try:
+                self.SD['site_internal_conversion_bath30'] = self.make_spectral_density(
+                    self.params['bath']['site_internal_conversion_bath30'])
             except KeyError:
                 pass
 
@@ -1039,7 +1190,7 @@ class SecularRedfieldConstructor:
                 Y2_ijij += b
                 Y2_ijji += c
 
-            if self.N == 3:
+            if self.N >= 3:
                 if 'site_bath2' in self.params['bath']:
 
                     for n in range(self.PolyVib.Polymer.num_sites):
@@ -1052,6 +1203,21 @@ class SecularRedfieldConstructor:
                         Y2_iikk += a2
                         Y2_ijij += b2
                         Y2_ijji += c2
+
+            if self.N >= 4:
+                if 'site_bath3' in self.params['bath']:
+
+                    for n in range(self.PolyVib.Polymer.num_sites):
+                        spectral_density = self.SD['site_bath3'][n]
+                        P_n3 = self.PolyVib.Polymer.triply_occupied_list[n]
+                        P_n3 = self.extract_electronic_operator(P_n3, manifold_key)
+
+                        P_n3 = np.kron(P_n3, self.PolyVib.vibrational_identity)
+                        a3, b3, c3 = self.make_dissipation_tensor(P_n3, manifold_key, spectral_density)
+                        Y2_iikk += a3
+                        Y2_ijij += b3
+                        Y2_ijji += c3
+
         else :
             spectral_density = self.SD['site_bath']
             size = self.eigenvalues[manifold_key].size
@@ -1070,7 +1236,7 @@ class SecularRedfieldConstructor:
                 Y2_ijij += b
                 Y2_ijji += c
 
-            if self.N == 3:
+            if self.N >= 3:
                 if 'site_bath2' in self.params['bath']:
                     spectral_density = self.SD['site_bath2']
 
@@ -1084,6 +1250,21 @@ class SecularRedfieldConstructor:
                         Y2_iikk += a2
                         Y2_ijij += b2
                         Y2_ijji += c2
+
+            if self.N >= 4:
+                if 'site_bath3' in self.params['bath']:
+                    spectral_density = self.SD['site_bath3']
+
+                    for n in range(self.PolyVib.Polymer.num_sites):
+
+                        P_n3 = self.PolyVib.Polymer.triply_occupied_list[n]
+                        P_n3 = self.extract_electronic_operator(P_n3, manifold_key)
+
+                        P_n3 = np.kron(P_n3, self.PolyVib.vibrational_identity)
+                        a3, b3, c3 = self.make_dissipation_tensor(P_n3, manifold_key, spectral_density)
+                        Y2_iikk += a3
+                        Y2_ijij += b3
+                        Y2_ijji += c3
 
         return Y2_iikk, Y2_ijij, Y2_ijji
 
@@ -1120,7 +1301,7 @@ class SecularRedfieldConstructor:
             Y3_ijij += b
             Y3_ijji += c
 
-        if self.N == 3:
+        if self.N >= 3:
             if 'site_internal_conversion_bath21' in self.params['bath']:
                 spectral_density = self.SD['site_internal_conversion_bath21']
                 manifold_key = 'all_manifolds'
@@ -1153,7 +1334,55 @@ class SecularRedfieldConstructor:
                     Y3_ijij += b20
                     Y3_ijji += c20
 
-                
+        if self.N >= 4:
+            if 'site_internal_conversion_bath32' in self.params['bath']:
+                spectral_density = self.SD['site_internal_conversion_bath32']
+                manifold_key = 'all_manifolds'
+
+                for n in range(self.PolyVib.Polymer.num_sites):
+
+                    up_n32 = self.PolyVib.Polymer.up32_list[n]
+                    up_n32 = self.extract_electronic_operator(up_n32, manifold_key)
+                    up_n32 = np.kron(up_n32, self.PolyVib.vibrational_identity)
+                    sigma_x_n32 = up_n32 + up_n32.T
+
+                    a32, b32, c32 = self.make_dissipation_tensor(sigma_x_n32, manifold_key, spectral_density)
+                    Y3_iikk += a32
+                    Y3_ijij += b32
+                    Y3_ijji += c32
+
+            if 'site_internal_conversion_bath31' in self.params['bath']:
+                spectral_density = self.SD['site_internal_conversion_bath31']
+                manifold_key = 'all_manifolds'
+
+                for n in range(self.PolyVib.Polymer.num_sites):
+
+                    up_n31 = self.PolyVib.Polymer.up31_list[n]
+                    up_n31 = self.extract_electronic_operator(up_n31, manifold_key)
+                    up_n31 = np.kron(up_n31, self.PolyVib.vibrational_identity)
+                    sigma_x_n31 = up_n31 + up_n31.T
+
+                    a31, b31, c31 = self.make_dissipation_tensor(sigma_x_n31, manifold_key, spectral_density)
+                    Y3_iikk += a31
+                    Y3_ijij += b31
+                    Y3_ijji += c31
+
+            if 'site_internal_conversion_bath30' in self.params['bath']:
+                spectral_density = self.SD['site_internal_conversion_bath30']
+                manifold_key = 'all_manifolds'
+
+                for n in range(self.PolyVib.Polymer.num_sites):
+
+                    up_n30 = self.PolyVib.Polymer.up30_list[n]
+                    up_n30 = self.extract_electronic_operator(up_n30, manifold_key)
+                    up_n30 = np.kron(up_n30, self.PolyVib.vibrational_identity)
+                    sigma_x_n30 = up_n30 + up_n30.T
+
+                    a30, b30, c30 = self.make_dissipation_tensor(sigma_x_n30, manifold_key, spectral_density)
+                    Y3_iikk += a30
+                    Y3_ijij += b30
+                    Y3_ijji += c30
+
         return Y3_iikk, Y3_ijij, Y3_ijji
 
     def make_R_from_Y(self,Yiikk,Yijij,Yijji):


### PR DESCRIPTION
Made by Claude

## Hamiltonians.py
- Add `set_triply_occupied_list` method and its call in the N==4 init block

## Redfield_Liouvillians.py
- Extend `RedfieldConstructor` and `SecularRedfieldConstructor` with `site_bath3` and IC baths for all 4LS transitions (bath32/31/30)
- Add N>=3/N>=4 guards in `make_Y2` and `make_Y3` for both classes

## PolymerVibrations (Hamiltonians.py)
- Change `N == 3` guards to `N >= 3` for doubly-occupied vibrational blocks in `set_vibrations` and `add_vibrations`
- Add parallel `N >= 4` blocks that compute triply-occupied vibrational Hamiltonians (`electronic_occupation=3`), kron them with the per-site `triply_occupied_list` projectors, and accumulate them into the total Hamiltonian

## tests/unit/test_polymer_hamiltonians.py
- Add `TestPolymerVibrations` class (17 tests) covering 2LS, 3LS, and 4LS
- Tests verify: `H.npz` is saved, correct occupied vibrational lists are populated for each N, vibrational Hamiltonian is nonzero and Hermitian, 4LS Hilbert space is larger than 3LS, and triply-occupied vibrations contribute to the total Hamiltonian